### PR TITLE
fix Uint64 accessor not supported by dart2js

### DIFF
--- a/lib/src/pin.dart
+++ b/lib/src/pin.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:x25519/x25519.dart';
+import 'package:fixnum/fixnum.dart';
 
 import 'util/cbc.dart';
 import 'util/crypto_util.dart';
@@ -31,12 +32,10 @@ String encryptPinWithIv(
   final keyBytes = X25519(curvePrivKey, public);
 
   final pinBytes = Uint8List.fromList(utf8.encode(pin));
-  final timeBytes = Uint8List(8);
-  final iteratorBytes = Uint8List(8);
-  // pin+time+iterator
-  timeBytes.buffer.asByteData().setUint64(0, nowSec, Endian.little);
-  iteratorBytes.buffer.asByteData().setUint64(0, iterator, Endian.little);
+  final timeBytes = Int64(nowSec).toBytes();
+  final iteratorBytes = Int64(iterator).toBytes();
 
+  // pin+time+iterator
   final plaintext = Uint8List.fromList(pinBytes + timeBytes + iteratorBytes);
   final ciphertext = aesCbcEncrypt(keyBytes, iv, plaintext);
   return base64Url.encode(iv + ciphertext);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   collection: ^1.15.0
   x25519: ^0.1.1
   pointycastle: ^3.6.1
+  fixnum: ^1.0.1
 
 dev_dependencies:
   test: ^1.17.9


### PR DESCRIPTION
Both app and browser are supported
ref from:
https://github.com/MixinNetwork/mixin-wallet/blob/main/lib/service/profile/pin_session.dart#L56