### PR TITLE
allow assigning audience to JWT

### DIFF
--- a/lib/src/auth.dart
+++ b/lib/src/auth.dart
@@ -19,25 +19,27 @@ String signAuthTokenWithRSA(
 String signAuthTokenWithEdDSA(
         String? userId,
         String? sessionId,
-        String? sessionPrivatateKey,
+        String? sessionPrivateKey,
         String? scp,
         String method,
         String uri,
-        String body) =>
+        String body,
+        {String? aud}) =>
     _signAuthenticationToken(
-        userId, sessionId, sessionPrivatateKey, scp, method, uri, body, false);
+        userId, sessionId, sessionPrivateKey, scp, method, uri, body, false,
+        aud: aud);
 
 String _signAuthenticationToken(
-  String? userId,
-  String? sessionId,
-  String? sessionPrivatateKey,
-  String? scp,
-  String method,
-  String uri,
-  String body,
-  bool isRSA,
-) {
-  if ([userId, sessionId, sessionPrivatateKey]
+    String? userId,
+    String? sessionId,
+    String? sessionPrivateKey,
+    String? scp,
+    String method,
+    String uri,
+    String body,
+    bool isRSA,
+    {String? aud}) {
+  if ([userId, sessionId, sessionPrivateKey]
       .any((element) => element?.isEmpty ?? true)) {
     return '';
   }
@@ -58,6 +60,10 @@ String _signAuthenticationToken(
     'scp': scp ?? 'FULL',
   });
 
-  final privateBytes = hex.decode(sessionPrivatateKey!);
+  if (aud != null) {
+    jwt.audience = Audience([aud]);
+  }
+
+  final privateBytes = hex.decode(sessionPrivateKey!);
   return jwt.sign(EdDSAPrivateKey(privateBytes), algorithm: JWTAlgorithm.EdDSA);
 }


### PR DESCRIPTION
Some bots need an `aud` added to the JWT ([like ExinOne](https://developers.exinone.com/guide/authentication.html#generate-mixin-token)). The PR simply fixes a spelling error and includes the optional `aud` parameter.