### PR TITLE
allow preference for asset fee over chain fee

### DIFF
--- a/lib/src/api/utxo_api.dart
+++ b/lib/src/api/utxo_api.dart
@@ -424,6 +424,7 @@ class UtxoApi {
     required String amount,
     String? tag,
     String? memo,
+    bool preferAssetFeeOverChainFee = false,
   }) async {
     final token = (await _tokenApi.getAssetById(asset)).data;
     final chain = token.chainId == token.assetId
@@ -432,8 +433,13 @@ class UtxoApi {
 
     final feeResponse =
         (await _tokenApi.getFees(asset: asset, destination: destination)).data;
-    final fee = feeResponse
+    late final assetFee =
+        feeResponse.firstWhereOrNull((element) => element.assetId == asset);
+    late final chainFee = feeResponse
         .firstWhereOrNull((element) => element.assetId == chain.assetId);
+
+    final fee =
+        (preferAssetFeeOverChainFee && assetFee != null) ? assetFee : chainFee;
     if (fee == null) {
       throw Exception('fee not found: $asset $feeResponse');
     }


### PR DESCRIPTION
An asset fee is often available along with the chain fee. The SDK is hard-coded to always select the chain fee. This allows the consumer of the API to prefer an asset fee, if available.

We could potentially also make this an enum:

```dart
enum FeeSpecification {
  preferChain,
  preferAsset,
  onlyChain,
  onlyAsset,
}
```

Where the default would be `FeeSpecification.onlyChain` to not break existing behavior. But I think this works for now.