### PR TITLE
refactor: revert to 1.2.10 with specific modifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.1
+
+* Revert to 1.2.10 with following exceptions preserved:
+  * Mark `deactive` and `deactiveVerification` as deprecated in favor of `deactivate` and `deactivateVerification`
+* Fix `queryAsset` and `search` api
+
 ## 1.3.0
 
 * Fix message offset api

--- a/lib/src/api/account_api.dart
+++ b/lib/src/api/account_api.dart
@@ -54,19 +54,19 @@ class AccountApi {
 
   Future<MixinResponse<StickerAlbum>> getStickerAlbum(String id) =>
       MixinResponse.request(
-        dio.get('/albums/${Uri.encodeComponent(id)}'),
+        dio.get('/albums/$id'),
         StickerAlbum.fromJson,
       );
 
   Future<MixinResponse<List<Sticker>>> getStickersByAlbumId(String id) =>
       MixinResponse.requestList(
-        dio.get('/stickers/albums/${Uri.encodeComponent(id)}'),
+        dio.get('/stickers/albums/$id'),
         Sticker.fromJson,
       );
 
   Future<MixinResponse<Sticker>> getStickerById(String id) =>
       MixinResponse.request<Sticker>(
-        dio.get('/stickers/${Uri.encodeComponent(id)}'),
+        dio.get('/stickers/$id'),
         Sticker.fromJson,
       );
 
@@ -88,7 +88,7 @@ class AccountApi {
 
   Future<MixinResponse<CodeTypeInterface?>> code(String id) =>
       MixinResponse.request<CodeTypeInterface?>(
-        dio.get('/codes/${Uri.encodeComponent(id)}'),
+        dio.get('/codes/$id'),
         (json) {
           try {
             final jsonObject = json;
@@ -123,7 +123,7 @@ class AccountApi {
 
   Future<MixinResponse<Account>> create(String id, AccountRequest request) =>
       MixinResponse.request<Account>(
-        dio.post('/verifications/${Uri.encodeComponent(id)}', data: request),
+        dio.post('/verifications/$id', data: request),
         Account.fromJson,
       );
 
@@ -173,7 +173,7 @@ class AccountApi {
     String code,
   ) =>
       MixinResponse.request<VerificationResponse>(
-        dio.post('/verifications/${Uri.encodeComponent(id)}', data: {
+        dio.post('/verifications/$id', data: {
           'code': code,
           'purpose': VerificationPurpose.deactivated.name.toUpperCase(),
         }),
@@ -194,9 +194,9 @@ class AccountApi {
   }) =>
       MixinResponse.requestList<LogResponse>(
         dio.get('/logs', queryParameters: {
-          if (category != null && category.isNotEmpty) 'category': category,
-          if (offset != null && offset.isNotEmpty) 'offset': offset,
-          if (limit != null) 'limit': limit,
+          'category': category,
+          'offset': offset,
+          'limit': limit,
         }),
         LogResponse.fromJson,
       );

--- a/lib/src/api/address_api.dart
+++ b/lib/src/api/address_api.dart
@@ -9,7 +9,7 @@ class AddressApi {
 
   Future<MixinResponse<List<Address>>> getAddressesByAssetId(String assetId) =>
       MixinResponse.requestList(
-        dio.get('/assets/${Uri.encodeComponent(assetId)}/addresses'),
+        dio.get('/assets/$assetId/addresses'),
         Address.fromJson,
       );
 
@@ -21,13 +21,13 @@ class AddressApi {
 
   Future<MixinResponse<Address>> getAddressById(String id) =>
       MixinResponse.request<Address>(
-        dio.get('/addresses/${Uri.encodeComponent(id)}'),
+        dio.get('/addresses/$id'),
         Address.fromJson,
       );
 
   Future<MixinResponse<void>> deleteAddressById(String id, String pin) =>
       MixinResponse.requestVoid(dio.post(
-        '/addresses/${Uri.encodeComponent(id)}/delete',
+        '/addresses/$id/delete',
         data: {'pin': pin},
       ));
 }

--- a/lib/src/api/asset_api.dart
+++ b/lib/src/api/asset_api.dart
@@ -14,13 +14,13 @@ class AssetApi {
 
   Future<MixinResponse<Asset>> getAssetById(String id) =>
       MixinResponse.request<Asset>(
-        dio.get('/assets/${Uri.encodeComponent(id)}'),
+        dio.get('/assets/$id'),
         Asset.fromJson,
       );
 
   Future<MixinResponse<AssetFee>> getAssetFee(String id) =>
       MixinResponse.request<AssetFee>(
-        dio.get('/assets/${Uri.encodeComponent(id)}/fee'),
+        dio.get('/assets/$id/fee'),
         AssetFee.fromJson,
       );
 
@@ -30,17 +30,13 @@ class AssetApi {
         Token.fromJson,
       );
 
-  Future<MixinResponse<List<PendingDeposit>>> pendingDeposits(
-    String? assetId, {
-    String? destination,
-    String? tag,
-  }) =>
+  Future<MixinResponse<List<PendingDeposit>>> pendingDeposits(String assetId,
+          {String? destination, String? tag}) =>
       MixinResponse.requestList(
         dio.get('/external/transactions', queryParameters: <String, dynamic>{
-          if (assetId != null && assetId.isNotEmpty) 'asset': assetId,
-          if (destination != null && destination.isNotEmpty)
-            'destination': destination,
-          if (tag != null && tag.isNotEmpty) 'tag': tag,
+          'asset': assetId,
+          'destination': destination,
+          'tag': tag,
         }),
         PendingDeposit.fromJson,
       );
@@ -58,7 +54,7 @@ class AssetApi {
 
   Future<MixinResponse<Chain>> getChain(String chainId) =>
       MixinResponse.request<Chain>(
-        dio.get('/network/chains/${Uri.encodeComponent(chainId)}'),
+        dio.get('/network/chains/$chainId'),
         Chain.fromJson,
       );
 }

--- a/lib/src/api/attachment_api.dart
+++ b/lib/src/api/attachment_api.dart
@@ -10,7 +10,7 @@ class AttachmentApi {
 
   Future<MixinResponse<Attachment>> getAttachment(String id) =>
       MixinResponse.request<Attachment>(
-        dio.get('/attachments/${Uri.encodeComponent(id)}'),
+        dio.get('/attachments/$id'),
         Attachment.fromJson,
       );
 

--- a/lib/src/api/circle_api.dart
+++ b/lib/src/api/circle_api.dart
@@ -19,7 +19,7 @@ class CircleApi {
 
   Future<MixinResponse<CircleResponse>> getCircle(String id) =>
       MixinResponse.request<CircleResponse>(
-        dio.get('/circles/${Uri.encodeComponent(id)}'),
+        dio.get('/circles/$id'),
         CircleResponse.fromJson,
       );
 
@@ -32,19 +32,18 @@ class CircleApi {
   Future<MixinResponse<CircleResponse>> updateCircle(
           String id, CircleName circleName) =>
       MixinResponse.request<CircleResponse>(
-        dio.post('/circles/${Uri.encodeComponent(id)}', data: circleName),
+        dio.post('/circles/$id', data: circleName),
         CircleResponse.fromJson,
       );
 
   Future<MixinResponse<void>> deleteCircle(String id) =>
-      MixinResponse.requestVoid(
-          dio.post('/circles/${Uri.encodeComponent(id)}/delete'));
+      MixinResponse.requestVoid(dio.post('/circles/$id/delete'));
 
   Future<MixinResponse<List<CircleConversation>>> updateCircleConversations(
           String id,
           List<CircleConversationRequest> conversationCircleRequests) =>
       MixinResponse.requestList(
-        dio.post('/circles/${Uri.encodeComponent(id)}/conversations',
+        dio.post('/circles/$id/conversations',
             data: conversationCircleRequests),
         CircleConversation.fromJson,
       );
@@ -54,11 +53,7 @@ class CircleApi {
           {String? offset,
           int limit = 500}) =>
       MixinResponse.requestList(
-        dio.get('/circles/${Uri.encodeComponent(id)}/conversations',
-            queryParameters: {
-              if (offset != null && offset.isNotEmpty) 'offset': offset,
-              'limit': limit,
-            }),
+        dio.get('/circles/$id/conversations?offset=$offset&limit=$limit'),
         CircleConversation.fromJson,
       );
 }

--- a/lib/src/api/conversation_api.dart
+++ b/lib/src/api/conversation_api.dart
@@ -17,61 +17,56 @@ class ConversationApi {
   Future<MixinResponse<ConversationResponse>> update(
           String conversationId, ConversationRequest request) =>
       MixinResponse.request<ConversationResponse>(
-        dio.post('/conversations/${Uri.encodeComponent(conversationId)}',
-            data: request),
+        dio.post('/conversations/$conversationId', data: request),
         ConversationResponse.fromJson,
       );
 
   Future<MixinResponse<void>> exit(String conversationId) =>
-      MixinResponse.requestVoid(dio
-          .post('/conversations/${Uri.encodeComponent(conversationId)}/exit'));
+      MixinResponse.requestVoid(
+          dio.post('/conversations/$conversationId/exit'));
 
   Future<MixinResponse<ConversationResponse>> getConversation(String id) =>
       MixinResponse.request<ConversationResponse>(
-        dio.get('/conversations/${Uri.encodeComponent(id)}'),
+        dio.get('/conversations/$id'),
         ConversationResponse.fromJson,
       );
 
   Future<MixinResponse<ConversationResponse>> updateConversation(String id) =>
       MixinResponse.request<ConversationResponse>(
-        dio.get('/conversations/${Uri.encodeComponent(id)}'),
+        dio.get('/conversations/$id'),
         ConversationResponse.fromJson,
       );
 
   Future<MixinResponse<ConversationResponse>> participants(
           String id, String action, List<ParticipantRequest> requests) =>
       MixinResponse.request<ConversationResponse>(
-        dio.post(
-            '/conversations/${Uri.encodeComponent(id)}/participants/${Uri.encodeComponent(action)}',
-            data: requests),
+        dio.post('/conversations/$id/participants/$action', data: requests),
         ConversationResponse.fromJson,
       );
 
   Future<MixinResponse<ConversationResponse>> mute(
           String id, ConversationRequest request) =>
       MixinResponse.request<ConversationResponse>(
-        dio.post('/conversations/${Uri.encodeComponent(id)}/mute',
-            data: request),
+        dio.post('/conversations/$id/mute', data: request),
         ConversationResponse.fromJson,
       );
 
   Future<MixinResponse<ConversationResponse>> rotate(String id) =>
       MixinResponse.request<ConversationResponse>(
-        dio.post('/conversations/${Uri.encodeComponent(id)}/rotate'),
+        dio.post('/conversations/$id/rotate'),
         ConversationResponse.fromJson,
       );
 
   Future<MixinResponse<ConversationResponse>> join(String id) =>
       MixinResponse.request(
-        dio.post('/conversations/${Uri.encodeComponent(id)}/join'),
+        dio.post('/conversations/$id/join'),
         ConversationResponse.fromJson,
       );
 
   Future<MixinResponse<ConversationResponse>> disappear(
           String id, DisappearRequest request) =>
       MixinResponse.request<ConversationResponse>(
-        dio.post('/conversations/${Uri.encodeComponent(id)}/disappear',
-            data: request),
+        dio.post('/conversations/$id/disappear', data: request),
         ConversationResponse.fromJson,
       );
 }

--- a/lib/src/api/message_api.dart
+++ b/lib/src/api/message_api.dart
@@ -11,8 +11,7 @@ class MessageApi {
       MixinResponse.requestVoid(dio.post('/acknowledgements', data: ack));
 
   Future<MixinResponse<List<BlazeMessageData>>> messageStatusOffset(
-    int offset,
-  ) =>
+          int offset) =>
       MixinResponse.requestList<BlazeMessageData>(
         dio.get('/messages/status/$offset'),
         BlazeMessageData.fromJson,

--- a/lib/src/api/provisioning_api.dart
+++ b/lib/src/api/provisioning_api.dart
@@ -19,7 +19,7 @@ class ProvisioningApi {
 
   Future<MixinResponse<Provisioning>> getProvisioning(String deviceId) =>
       MixinResponse.request<Provisioning>(
-        dio.get('/provisionings/${Uri.encodeComponent(deviceId)}'),
+        dio.get('/provisionings/$deviceId'),
         Provisioning.fromJson,
       );
 

--- a/lib/src/api/snapshot_api.dart
+++ b/lib/src/api/snapshot_api.dart
@@ -16,40 +16,35 @@ class SnapshotApi {
           String? tag}) =>
       MixinResponse.requestList(
         dio.get('/snapshots', queryParameters: <String, dynamic>{
-          if (assetId != null && assetId.isNotEmpty) 'asset': assetId,
-          if (offset != null && offset.isNotEmpty) 'offset': offset,
+          'asset': assetId,
+          'offset': offset,
           'limit': limit,
-          if (opponent != null && opponent.isNotEmpty) 'opponent': opponent,
-          if (destination != null && destination.isNotEmpty)
-            'destination': destination,
-          if (tag != null && tag.isNotEmpty) 'tag': tag,
+          'opponent': opponent,
+          'destination': destination,
+          'tag': tag,
         }),
         Snapshot.fromJson,
       );
 
   Future<MixinResponse<Snapshot>> getSnapshotById(String id) =>
       MixinResponse.request<Snapshot>(
-        dio.get('/snapshots/${Uri.encodeComponent(id)}'),
+        dio.get('/snapshots/$id'),
         Snapshot.fromJson,
       );
 
-  Future<MixinResponse<List<Snapshot>>> getSnapshotsByAssetId(
-    String id, {
-    String? offset,
-    int limit = 30,
-  }) =>
+  Future<MixinResponse<List<Snapshot>>> getSnapshotsByAssetId(String id,
+          {String? offset, int limit = 30}) =>
       MixinResponse.requestList(
-        dio.get('/assets/${Uri.encodeComponent(id)}/snapshots',
-            queryParameters: <String, dynamic>{
-              if (offset != null && offset.isNotEmpty) 'offset': offset,
-              'limit': limit,
-            }),
+        dio.get('/assets/$id/snapshots', queryParameters: <String, dynamic>{
+          'offset': offset,
+          'limit': limit,
+        }),
         Snapshot.fromJson,
       );
 
   Future<MixinResponse<Snapshot>> getSnapshotByTraceId(String traceId) =>
       MixinResponse.request(
-        dio.get('/snapshots/trace/${Uri.encodeComponent(traceId)}'),
+        dio.get('/snapshots/trace/$traceId'),
         Snapshot.fromJson,
       );
 
@@ -57,7 +52,7 @@ class SnapshotApi {
       MixinResponse.request(
         dio.get('/network/ticker', queryParameters: <String, dynamic>{
           'asset': assetId,
-          if (offset != null && offset.isNotEmpty) 'offset': offset,
+          'offset': offset,
         }),
         Ticker.fromJson,
       );

--- a/lib/src/api/user_api.dart
+++ b/lib/src/api/user_api.dart
@@ -14,7 +14,7 @@ class UserApi {
 
   Future<MixinResponse<User>> getUserById(String id) =>
       MixinResponse.request<User>(
-        dio.get('/users/${Uri.encodeComponent(id)}'),
+        dio.get('/users/$id'),
         User.fromJson,
       );
 
@@ -56,12 +56,12 @@ class UserApi {
 
   Future<MixinResponse<List<FavoriteApp>>> getUserFavoriteApps(String userId) =>
       MixinResponse.requestList(
-        dio.get('/users/${Uri.encodeComponent(userId)}/apps/favorite'),
+        dio.get('/users/$userId/apps/favorite'),
         FavoriteApp.fromJson,
       );
 
   Future<void> removeFavoriteApp(String appId) => MixinResponse.requestVoid(
-        dio.post('/apps/${Uri.encodeComponent(appId)}/unfavorite'),
+        dio.post('/apps/$appId/unfavorite'),
       );
 
   /// Create Network Users. Only application user can create network users.

--- a/lib/src/vo/request/circle_conversation_request.g.dart
+++ b/lib/src/vo/request/circle_conversation_request.g.dart
@@ -20,12 +20,21 @@ CircleConversationRequest _$CircleConversationRequestFromJson(
 }
 
 Map<String, dynamic> _$CircleConversationRequestToJson(
-        CircleConversationRequest instance) =>
-    <String, dynamic>{
-      'conversation_id': instance.conversationId,
-      'action': _$CircleConversationActionEnumMap[instance.action]!,
-      if (instance.userId case final value?) 'user_id': value,
-    };
+    CircleConversationRequest instance) {
+  final val = <String, dynamic>{
+    'conversation_id': instance.conversationId,
+    'action': _$CircleConversationActionEnumMap[instance.action]!,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('user_id', instance.userId);
+  return val;
+}
 
 const _$CircleConversationActionEnumMap = {
   CircleConversationAction.add: 'ADD',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mixin_bot_sdk_dart
 description: Mixin Messenger API for Dart/Flutter, build decentrialized applications on Mixin
-version: 1.3.0
+version: 1.3.1
 homepage: https://github.com/MixinNetwork/mixin_bot_sdk_dart
 
 environment:

--- a/test/token_api_test.dart
+++ b/test/token_api_test.dart
@@ -14,11 +14,9 @@ void main() {
   test('test getAllSnapshots', () async {
     try {
       final resp = await client.tokenApi.getAllSnapshots();
-      // ignore: avoid_print
       print(jsonEncode(resp.data));
     } catch (e) {
       if (e is MixinApiError) {
-        // ignore: avoid_print
         print(e.error);
       }
     }


### PR DESCRIPTION
* Revert to version 1.2.10 while preserving:
  - Deprecation of `deactive` and `deactiveVerification` methods
  - Fixes for `queryAsset` and `search` API
* Remove URI encoding for path parameters
* Simplify query parameter handling across multiple APIs
* Update version to 1.3.1